### PR TITLE
GH Action to redeploy the chatbot

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,13 @@
+name: Redeploy
+on: pull_request
+env:
+  GIGALIXIR_REMOTE: ${{ secrets.GIGALIXIR_REMOTE }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          git commit --allow-empty -m "trigger deploy"
+          git remote add gigalixir $GIGALIXIR_REMOTE
+          git push gigalixir master

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: |
-          git commit --allow-empty -m "trigger deploy"
+          git -c user.name='Gigalixir GH Action' -c user.email='dosmun+github@gmail.com' commit --allow-empty -m "trigger deploy"
           git remote add gigalixir $GIGALIXIR_REMOTE
           git push gigalixir master

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -8,6 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: |
-          git -c user.name='Gigalixir GH Action' -c user.email='dosmun+github@gmail.com' commit --allow-empty -m "trigger deploy"
-          git remote add gigalixir $GIGALIXIR_REMOTE
-          git push gigalixir master
+          git checkout -B redeploy
+          git push "${GIGALIXIR_REMOTE}" redeploy:master

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,5 +1,7 @@
 name: Redeploy
-on: pull_request
+on:
+  schedule:
+    - cron: '0 6 * * *'
 env:
   GIGALIXIR_REMOTE: ${{ secrets.GIGALIXIR_REMOTE }}
 jobs:


### PR DESCRIPTION
Gigalixir shuts down your app if you don't deploy at least every 45 days. This action will cause a re-deploy monthly.

The cron is currently set up to redeploy daily to verify that pushing no changes still causes a redeploy. Once that's verified we can update the cron to monthly.
